### PR TITLE
Use getAttribute instead of .dataset

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var document = require('global/document')
 var window = require('global/window')
 var watch = []
 var KEY_ID = 'onloadid' + (new Date() % 9e6).toString(36)
+var KEY_ATTR = 'data-' + KEY_ID
 var INDEX = 0
 
 if (window && window.MutationObserver) {
@@ -30,7 +31,7 @@ if (window && window.MutationObserver) {
 module.exports = function onload (el, on, off) {
   on = on || function () {}
   off = off || function () {}
-  el.dataset[KEY_ID] = INDEX
+  el.setAttribute(KEY_ATTR, INDEX)
   watch.push([INDEX.toString(), on, off])
   INDEX += 1
 }
@@ -38,9 +39,9 @@ module.exports = function onload (el, on, off) {
 function eachMutation (nodes, fn) {
   if (watch.length < 1) return
   for (var i = 0; i < nodes.length; i++) {
-    if (nodes[i] && nodes[i].dataset && nodes[i].dataset[KEY_ID]) {
+    if (nodes[i] && nodes[i].getAttribute && nodes[i].getAttribute(KEY_ATTR)) {
       for (var j = 0; j < watch.length; j++) {
-        if (watch[j][0] === nodes[i].dataset[KEY_ID]) {
+        if (watch[j][0] === nodes[i].getAttribute(KEY_ATTR)) {
           fn(j)
         }
       }


### PR DESCRIPTION
I noticed that after adding `on-load` to my app, my test broke because `jsdom` doesn't support `.dataset` (tmpvar/jsdom#961). Changing from `.dataset` to `.getAttribute('data-...')` does the trick. The question is (a) whether there are any other use cases other than jsdom, and (b) whether there's any advantage of using `.dataset` that we'd lose by using `.getAttribute()`.
