### PR TITLE
Pass element reference to callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ On load/unload events for DOM elements using a MutationObserver
 var onload = require('on-load')
 
 var div = document.createElement('div')
-onload(div, function () {
+onload(div, function (el) {
   console.log('in the dom')
-}, function () {
+}, function (el) {
   console.log('out of the dom')
 })
 

--- a/index.js
+++ b/index.js
@@ -36,16 +36,16 @@ module.exports = function onload (el, on, off) {
   return el
 }
 
-function turnon (index) {
+function turnon (index, el) {
   if (watch[index][0] && watch[index][2] === 0) {
-    watch[index][0]()
+    watch[index][0](el)
     watch[index][2] = 1
   }
 }
 
-function turnoff (index) {
+function turnoff (index, el) {
   if (watch[index][1] && watch[index][2] === 1) {
-    watch[index][1]()
+    watch[index][1](el)
     watch[index][2] = 0
   }
 }
@@ -61,10 +61,10 @@ function eachAttr (mutation, on, off) {
   }
   Object.keys(watch).forEach(function (k) {
     if (mutation.oldValue === k) {
-      off(k)
+      off(k, mutation.target)
     }
     if (newValue === k) {
-      on(k)
+      on(k, mutation.target)
     }
   })
 }
@@ -80,7 +80,7 @@ function eachMutation (nodes, fn) {
       var onloadid = nodes[i].getAttribute(KEY_ATTR)
       keys.forEach(function (k) {
         if (onloadid === k) {
-          fn(k)
+          fn(k, nodes[i])
         }
       })
     }

--- a/test.js
+++ b/test.js
@@ -17,6 +17,37 @@ test('onload/onunload', function (t) {
   document.body.removeChild(el)
 })
 
+test('passed el reference', function (t) {
+  t.plan(4)
+  function page1 () {
+    var tree = yo`<div>page1</div>`
+    return onload(tree, function (el) {
+      t.equal(el, tree, 'onload passed element reference for page1')
+    }, function (el) {
+      t.equal(el, tree, 'onunload passed element reference for page1')
+    })
+  }
+  function page2 () {
+    var tree = yo`<div>page2</div>`
+    return onload(tree, function (el) {
+      t.equal(el.textContent, 'page2', 'onload passed element reference for page2')
+    }, function (el) {
+      t.equal(el.textContent, 'page2', 'onunload passed element reference for page2')
+    })
+  }
+
+  var root = page1()
+  document.body.appendChild(root)
+  runops([
+    function () {
+      root = yo.update(root, page2())
+    },
+    function () {
+      root.parentNode.removeChild(root)
+    }
+  ])
+})
+
 test('nested', function (t) {
   t.plan(2)
   var e1 = document.createElement('div')


### PR DESCRIPTION
Closes #7 without keeping the element reference around. Please take a close look as I haven't worked with mutation observers before, but this looks like it does the trick!
