### PR TITLE
Use Object.keys().length to test for watchers

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var INDEX = 0
 
 if (window && window.MutationObserver) {
   var observer = new MutationObserver(function (mutations) {
-    if (watch.length < 1) return
+    if (Object.keys(watch).length < 1) return
     for (var i = 0; i < mutations.length; i++) {
       if (mutations[i].attributeName === KEY_ATTR) {
         eachAttr(mutations[i], turnon, turnoff)


### PR DESCRIPTION
Presently, `watch.length` is always `undefined` because objects don't have a `length` property, so the `for` loop that follows gets called even when nothing is being watched. `Object.keys()` gets an array of the object's keys, which provides the `length` property we're after. [Browser support](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys#Browser_compatibility) is IE9+.
