### PR TITLE
Use latest on/off callbacks from a particular caller

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ On load/unload events for DOM elements using a MutationObserver
 ## usage
 
 ```js
-var onload = require('on-load')
+const onload = require('on-load')
 
-var div = document.createElement('div')
+const div = document.createElement('div')
 onload(div, function (el) {
   console.log('in the dom')
 }, function (el) {

--- a/index.js
+++ b/index.js
@@ -1,15 +1,15 @@
 /* global MutationObserver */
-var document = require('global/document')
-var window = require('global/window')
-var watch = Object.create(null)
-var KEY_ID = 'onloadid' + Math.random().toString(36).slice(2)
-var KEY_ATTR = 'data-' + KEY_ID
-var INDEX = 0
+const document = require('global/document')
+const window = require('global/window')
+const watch = Object.create(null)
+const KEY_ID = 'onloadid' + Math.random().toString(36).slice(2)
+const KEY_ATTR = 'data-' + KEY_ID
+let INDEX = 0
 
 if (window && window.MutationObserver) {
-  var observer = new MutationObserver(function (mutations) {
+  const observer = new MutationObserver(function (mutations) {
     if (Object.keys(watch).length < 1) return
-    for (var i = 0; i < mutations.length; i++) {
+    for (let i = 0; i < mutations.length; i++) {
       if (mutations[i].attributeName === KEY_ATTR) {
         eachAttr(mutations[i], turnon, turnoff)
         continue
@@ -59,7 +59,7 @@ function turnoff (index, el) {
 }
 
 function eachAttr (mutation, on, off) {
-  var newValue = mutation.target.getAttribute(KEY_ATTR)
+  const newValue = mutation.target.getAttribute(KEY_ATTR)
   if (sameOrigin(mutation.oldValue, newValue)) {
     watch[newValue][2] = watch[mutation.oldValue][2]
     return
@@ -78,10 +78,10 @@ function sameOrigin (oldValue, newValue) {
 }
 
 function eachMutation (nodes, fn) {
-  var keys = Object.keys(watch)
-  for (var i = 0; i < nodes.length; i++) {
+  const keys = Object.keys(watch)
+  for (let i = 0; i < nodes.length; i++) {
     if (nodes[i] && nodes[i].getAttribute && nodes[i].getAttribute(KEY_ATTR)) {
-      var onloadid = nodes[i].getAttribute(KEY_ATTR)
+      const onloadid = nodes[i].getAttribute(KEY_ATTR)
       keys.forEach(function (k) {
         if (onloadid === k) {
           fn(k, nodes[i])

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function turnoff (index, el) {
 function eachAttr (mutation, on, off) {
   var newValue = mutation.target.getAttribute(KEY_ATTR)
   if (sameOrigin(mutation.oldValue, newValue)) {
-    watch[newValue] = watch[mutation.oldValue]
+    watch[newValue][2] = watch[mutation.oldValue][2]
     return
   }
   if (watch[mutation.oldValue]) {

--- a/package.json
+++ b/package.json
@@ -34,13 +34,13 @@
   "homepage": "https://github.com/shama/on-load",
   "dependencies": {
     "global": "^4.3.2",
-    "nanoassert": "^1.1.0"
+    "nanoassert": "^2.0.0"
   },
   "devDependencies": {
-    "browserify": "^16.2.2",
-    "standard": "^11.0.1",
-    "tape": "^4.6.0",
-    "tape-run": "^4.0.0",
+    "browserify": "^17.0.0",
+    "standard": "^17.0.0",
+    "tape": "^5.6.3",
+    "tape-run": "^10.0.0",
     "wzrd": "^1.4.0",
     "yo-yo": "^1.2.1"
   }

--- a/server.js
+++ b/server.js
@@ -1,4 +1,4 @@
-var window = require('global/window')
+const window = require('global/window')
 
 if (isElectron()) {
   module.exports = require('./index.js') // explicite relative import to avoid browser field

--- a/test.js
+++ b/test.js
@@ -1,10 +1,10 @@
-var onload = require('./')
-var test = require('tape')
-var yo = require('yo-yo')
+const onload = require('./')
+const test = require('tape')
+const yo = require('yo-yo')
 
 test('onload/onunload', function (t) {
   t.plan(2)
-  var el = document.createElement('div')
+  const el = document.createElement('div')
   el.textContent = 'test'
   onload(el, function () {
     t.ok(true, 'onload called')
@@ -19,7 +19,7 @@ test('onload/onunload', function (t) {
 
 test('assign key attr', function (t) {
   t.plan(1)
-  var el = document.createElement('div')
+  const el = document.createElement('div')
   el.textContent = 'test'
   onload(el)
   t.ok(el.hasAttribute(onload.KEY_ATTR), 'has correct key attr')
@@ -28,7 +28,7 @@ test('assign key attr', function (t) {
 test('passed el reference', function (t) {
   t.plan(4)
   function page1 () {
-    var tree = yo`<div>page1</div>`
+    const tree = yo`<div>page1</div>`
     return onload(tree, function (el) {
       t.equal(el, tree, 'onload passed element reference for page1')
     }, function (el) {
@@ -36,7 +36,7 @@ test('passed el reference', function (t) {
     })
   }
   function page2 () {
-    var tree = yo`<div>page2</div>`
+    const tree = yo`<div>page2</div>`
     return onload(tree, function (el) {
       t.equal(el.textContent, 'page2', 'onload passed element reference for page2')
     }, function (el) {
@@ -44,7 +44,7 @@ test('passed el reference', function (t) {
     })
   }
 
-  var root = page1()
+  let root = page1()
   document.body.appendChild(root)
   runops([
     function () {
@@ -58,12 +58,12 @@ test('passed el reference', function (t) {
 
 test('nested', function (t) {
   t.plan(2)
-  var e1 = document.createElement('div')
-  var e2 = document.createElement('div')
+  const e1 = document.createElement('div')
+  const e2 = document.createElement('div')
   e1.appendChild(e2)
   document.body.appendChild(e1)
 
-  var e3 = document.createElement('div')
+  const e3 = document.createElement('div')
   onload(e3, function () {
     t.ok(true, 'onload called')
     e2.removeChild(e3)
@@ -77,10 +77,10 @@ test('nested', function (t) {
 
 test('complex', function (t) {
   t.plan(3)
-  var state = []
+  let state = []
 
   function button () {
-    var el = yo`<button>click</button>`
+    const el = yo`<button>click</button>`
     onload(el, function () {
       state.push('on')
     }, function () {
@@ -89,7 +89,7 @@ test('complex', function (t) {
     return el
   }
 
-  var root = yo`<div>
+  let root = yo`<div>
     ${button()}
   </div>`
   document.body.appendChild(root)
@@ -103,7 +103,7 @@ test('complex', function (t) {
     function () {
       t.deepEqual(state, ['off'], 'turn off')
       state = []
-      var btn = button()
+      const btn = button()
       root = yo.update(root, yo`<p><div>${btn}</div></p>`)
       root = yo.update(root, yo`<p>
         <div>Updated</div>
@@ -121,9 +121,9 @@ test('complex', function (t) {
 
 test('complex nested', function (t) {
   t.plan(7)
-  var state = []
+  let state = []
   function button () {
-    var el = yo`<button>click</button>`
+    const el = yo`<button>click</button>`
     onload(el, function () {
       state.push('on')
     }, function () {
@@ -138,7 +138,7 @@ test('complex nested', function (t) {
     </div>`
   }
 
-  var root = app(yo`<div>Loading...</div>`)
+  let root = app(yo`<div>Loading...</div>`)
   document.body.appendChild(root)
 
   runops([
@@ -197,7 +197,7 @@ test('complex nested', function (t) {
 
 test('fire on same node but not from the same caller', function (t) {
   t.plan(1)
-  var results = []
+  const results = []
   function page1 (contents) {
     return onload(yo`<div id="choo-root">${contents}</div>`, function () {
       results.push('page1 on')
@@ -212,7 +212,7 @@ test('fire on same node but not from the same caller', function (t) {
       results.push('page2 off')
     })
   }
-  var root = page1()
+  let root = page1()
   document.body.appendChild(root)
   runops([
     function () {
@@ -237,7 +237,7 @@ test('fire on same node but not from the same caller', function (t) {
       document.body.removeChild(root)
     }
   ], function () {
-    var expected = [
+    const expected = [
       'page1 on',
       'page1 off',
       'page2 on',
@@ -252,7 +252,7 @@ test('fire on same node but not from the same caller', function (t) {
 
 test('operates with memoized elements', function (t) {
   t.plan(1)
-  var results = []
+  const results = []
   function sub () {
     return onload(yo`<div>sub</div>`, function () {
       results.push('sub on')
@@ -260,7 +260,7 @@ test('operates with memoized elements', function (t) {
       results.push('sub off')
     })
   }
-  var saved = null
+  let saved = null
   function parent () {
     saved = saved || onload(yo`<div>parent${sub()}</div>`, function () {
       results.push('parent on')
@@ -272,9 +272,9 @@ test('operates with memoized elements', function (t) {
   function app () {
     return yo`<div>${parent()}</div>`
   }
-  var root = app()
+  const root = app()
   document.body.appendChild(root)
-  var interval = setInterval(function () {
+  const interval = setInterval(function () {
     yo.update(root, app())
   }, 10)
   setTimeout(function () {
@@ -286,7 +286,7 @@ test('operates with memoized elements', function (t) {
 
 test('use latest callbacks from particular caller', function (t) {
   t.plan(1)
-  var results = []
+  const results = []
   function page (contents) {
     return onload(yo`<div id="choo-root">${contents}</div>`, function () {
       results.push('page on: ' + contents)
@@ -294,7 +294,7 @@ test('use latest callbacks from particular caller', function (t) {
       results.push('page off: ' + contents)
     })
   }
-  var root = page('render1')
+  let root = page('render1')
   document.body.appendChild(root)
   runops([
     function () {
@@ -307,7 +307,7 @@ test('use latest callbacks from particular caller', function (t) {
       document.body.removeChild(root)
     }
   ], function () {
-    var expected = [
+    const expected = [
       'page on: render1',
       'page off: render3'
     ]
@@ -318,7 +318,7 @@ test('use latest callbacks from particular caller', function (t) {
 
 function runops (ops, done) {
   function loop () {
-    var next = ops.shift()
+    const next = ops.shift()
     if (next) {
       next()
       setTimeout(loop, 10)

--- a/test.js
+++ b/test.js
@@ -284,6 +284,38 @@ test('operates with memoized elements', function (t) {
   }, 100)
 })
 
+test('use latest callbacks from particular caller', function (t) {
+  t.plan(1)
+  var results = []
+  function page (contents) {
+    return onload(yo`<div id="choo-root">${contents}</div>`, function () {
+      results.push('page on: ' + contents)
+    }, function () {
+      results.push('page off: ' + contents)
+    })
+  }
+  var root = page('render1')
+  document.body.appendChild(root)
+  runops([
+    function () {
+      root = yo.update(root, page('render2'))
+    },
+    function () {
+      root = yo.update(root, page('render3'))
+    },
+    function () {
+      document.body.removeChild(root)
+    }
+  ], function () {
+    var expected = [
+      'page on: render1',
+      'page off: render3'
+    ]
+    t.deepEqual(results, expected)
+    t.end()
+  })
+})
+
 function runops (ops, done) {
   function loop () {
     var next = ops.shift()


### PR DESCRIPTION
This PR addresses an edge case of `on-load` that has unintuitive behaviour. Specifically:
* onload is called multiple times on an element, by the same caller
* each onload call is made with new `on` and `off` functions (compared to the previous call)
* when the `off` callback is eventually triggered on the element, the oldest `off` function supplied is called. This is unintuitive, as the `off` function was superceded in later calls to onload.

This PR changes the behaviour to use the latest `off` function supplied instead, which seems more intuitive. It would also use the latest `on` function too, but I don't think this callback would ever called.

The PR changes

```
function eachAttr (mutation, on, off) {
  ..
  if (sameOrigin(mutation.oldValue, newValue)) {
    watch[newValue] = watch[mutation.oldValue]
    ..
  }
```
to
```
function eachAttr (mutation, on, off) {
  ..
  if (sameOrigin(mutation.oldValue, newValue)) {
    watch[newValue][2] = watch[mutation.oldValue][2]
    ..
  }
```
So previously the latest `watch` array for an element was overwritten with the earlier `watch` array; this means that the earlier `on`/`off` functions are always used in element callbacks. In this PR, we only overwrite `watch[newValue][2]` with `watch[mutation.oldValue][2]`, which I believe indicates whether `on` or `off` was called last. So the later `on`/`off` functions are used as element callbacks instead.








