### PR TITLE
Starting observer only after DOM has loaded

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,13 +18,9 @@ if (window && window.MutationObserver) {
       eachMutation(mutations[i].addedNodes, turnon)
     }
   })
-  observer.observe(document.body, {
-    childList: true,
-    subtree: true,
-    attributes: true,
-    attributeOldValue: true,
-    attributeFilter: [KEY_ATTR]
-  })
+
+  if (document.readyState === 'complete') startObserving(observer)()
+  else document.addEventListener('DOMContentLoaded', startObserving(observer))
 }
 
 module.exports = function onload (el, on, off, caller) {
@@ -34,6 +30,18 @@ module.exports = function onload (el, on, off, caller) {
   watch['o' + INDEX] = [on, off, 0, caller || onload.caller]
   INDEX += 1
   return el
+}
+
+function startObserving (obs) {
+  return function () {
+    obs.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeOldValue: true,
+      attributeFilter: [KEY_ATTR]
+    })
+  }
 }
 
 function turnon (index, el) {


### PR DESCRIPTION
This PR makes it so the `MutationObserver` only kicks off if/after the DOM has fully loaded.

### Rationale
This prevents issues when `document.body` isn't present for any reason. One might argue that it is the developer's responsibility to ensure that the code doesn't execute before `body` exists. I think it's better to account for that in the module itself.

Likely fixes #14 

### Implementation notes

Using `DOMContentLoaded` and checking for `complete` readystate because I'm assuming you don't support <IE10 anyway.

Using a higher-order function for the event handler for purity and the good of all humankind.

### Checklist

- [x] tests: 19/19 passed
- [x] style: `node node_modules/.bin/standard` does not return any warnings


💥