### PR TITLE
allow for multiple onloads

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,87 +1,100 @@
 /* global MutationObserver */
 var document = require('global/document')
 var window = require('global/window')
-var watch = Object.create(null)
-var KEY_ID = 'onloadid' + (new Date() % 9e6).toString(36)
-var KEY_ATTR = 'data-' + KEY_ID
-var INDEX = 0
 
-if (window && window.MutationObserver) {
-  var observer = new MutationObserver(function (mutations) {
-    if (Object.keys(watch).length < 1) return
-    for (var i = 0; i < mutations.length; i++) {
-      if (mutations[i].attributeName === KEY_ATTR) {
-        eachAttr(mutations[i], turnon, turnoff)
-        continue
-      }
-      eachMutation(mutations[i].removedNodes, turnoff)
-      eachMutation(mutations[i].addedNodes, turnon)
-    }
-  })
-  observer.observe(document.body, {
-    childList: true,
-    subtree: true,
-    attributes: true,
-    attributeOldValue: true,
-    attributeFilter: [KEY_ATTR]
-  })
-}
+module.exports = Onload
 
-module.exports = function onload (el, on, off, caller) {
-  on = on || function () {}
-  off = off || function () {}
-  el.setAttribute(KEY_ATTR, 'o' + INDEX)
-  watch['o' + INDEX] = [on, off, 0, caller || onload.caller]
-  INDEX += 1
-  return el
-}
+function Onload (root) {
+  root = root || document.body
 
-function turnon (index, el) {
-  if (watch[index][0] && watch[index][2] === 0) {
-    watch[index][0](el)
-    watch[index][2] = 1
-  }
-}
+  var watch = Object.create(null)
+  var KEY_ID = 'onloadid' + (new Date() % 9e6).toString(36)
+  var KEY_ATTR = 'data-' + KEY_ID
+  var INDEX = 0
 
-function turnoff (index, el) {
-  if (watch[index][1] && watch[index][2] === 1) {
-    watch[index][1](el)
-    watch[index][2] = 0
-  }
-}
-
-function eachAttr (mutation, on, off) {
-  var newValue = mutation.target.getAttribute(KEY_ATTR)
-  if (sameOrigin(mutation.oldValue, newValue)) {
-    watch[newValue] = watch[mutation.oldValue]
-    return
-  }
-  if (watch[mutation.oldValue]) {
-    off(mutation.oldValue, mutation.target)
-  }
-  if (watch[newValue]) {
-    on(newValue, mutation.target)
-  }
-}
-
-function sameOrigin (oldValue, newValue) {
-  if (!oldValue || !newValue) return false
-  return watch[oldValue][3] === watch[newValue][3]
-}
-
-function eachMutation (nodes, fn) {
-  var keys = Object.keys(watch)
-  for (var i = 0; i < nodes.length; i++) {
-    if (nodes[i] && nodes[i].getAttribute && nodes[i].getAttribute(KEY_ATTR)) {
-      var onloadid = nodes[i].getAttribute(KEY_ATTR)
-      keys.forEach(function (k) {
-        if (onloadid === k) {
-          fn(k, nodes[i])
+  if (window && window.MutationObserver) {
+    var observer = new MutationObserver(function (mutations) {
+      if (Object.keys(watch).length < 1) return
+      for (var i = 0; i < mutations.length; i++) {
+        if (mutations[i].attributeName === KEY_ATTR) {
+          eachAttr(mutations[i], turnon, turnoff)
+          continue
         }
-      })
+        eachMutation(mutations[i].removedNodes, turnoff)
+        eachMutation(mutations[i].addedNodes, turnon)
+      }
+    })
+    observer.observe(root, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeOldValue: true,
+      attributeFilter: [KEY_ATTR]
+    })
+  }
+
+  function onload (el, on, off, caller) {
+    on = on || function () {}
+    off = off || function () {}
+    el.setAttribute(KEY_ATTR, 'o' + INDEX)
+    watch['o' + INDEX] = [on, off, 0, caller || onload.caller]
+    INDEX += 1
+    return el
+  }
+
+  onload.end = function () {
+    return observer.disconnect
+  }
+
+  return onload
+
+  function turnon (index, el) {
+    if (watch[index][0] && watch[index][2] === 0) {
+      watch[index][0](el)
+      watch[index][2] = 1
     }
-    if (nodes[i].childNodes.length > 0) {
-      eachMutation(nodes[i].childNodes, fn)
+  }
+
+  function turnoff (index, el) {
+    if (watch[index][1] && watch[index][2] === 1) {
+      watch[index][1](el)
+      watch[index][2] = 0
+    }
+  }
+
+  function eachAttr (mutation, on, off) {
+    var newValue = mutation.target.getAttribute(KEY_ATTR)
+    if (sameOrigin(mutation.oldValue, newValue)) {
+      watch[newValue] = watch[mutation.oldValue]
+      return
+    }
+    if (watch[mutation.oldValue]) {
+      off(mutation.oldValue, mutation.target)
+    }
+    if (watch[newValue]) {
+      on(newValue, mutation.target)
+    }
+  }
+
+  function sameOrigin (oldValue, newValue) {
+    if (!oldValue || !newValue) return false
+    return watch[oldValue][3] === watch[newValue][3]
+  }
+
+  function eachMutation (nodes, fn) {
+    var keys = Object.keys(watch)
+    for (var i = 0; i < nodes.length; i++) {
+      if (nodes[i] && nodes[i].getAttribute && nodes[i].getAttribute(KEY_ATTR)) {
+        var onloadid = nodes[i].getAttribute(KEY_ATTR)
+        keys.forEach(function (k) {
+          if (onloadid === k) {
+            fn(k, nodes[i])
+          }
+        })
+      }
+      if (nodes[i].childNodes.length > 0) {
+        eachMutation(nodes[i].childNodes, fn)
+      }
     }
   }
 }


### PR DESCRIPTION
hey! here's a pull request to fix https://github.com/shama/bel/issues/60.

this is a breaking change:

> now exports function that receives root node (default: document.body) and returns what was previously exported (the `onload` function).
>
> this allows mutation observations to happen when the export is explicitly called, rather than when the module is required. because of this, there is now also a `.end()` function attached to the `onload` function returned which disconnects the mutation observer.

i'm not sure if this is the **best** way, but it works and was easy to implement. open to alternative implementation ideas. :smile: