### PR TITLE
Update to export key attr variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,8 @@ module.exports = function onload (el, on, off, caller) {
   return el
 }
 
+module.exports.KEY_ATTR = KEY_ATTR
+
 function turnon (index, el) {
   if (watch[index][0] && watch[index][2] === 0) {
     watch[index][0](el)

--- a/test.js
+++ b/test.js
@@ -17,6 +17,14 @@ test('onload/onunload', function (t) {
   document.body.removeChild(el)
 })
 
+test('assign key attr', function (t) {
+  t.plan(1)
+  var el = document.createElement('div')
+  el.textContent = 'test'
+  onload(el)
+  t.ok(el.hasAttribute(onload.KEY_ATTR), 'has correct key attr')
+})
+
 test('passed el reference', function (t) {
   t.plan(4)
   function page1 () {


### PR DESCRIPTION
Currently in order to confirm whether a node has had `on-load` applied correctly I have to do a fairly gnarly brute force against `/^data-onloadid/.test(node.attributes[...].name)`.

I feel like by exposing the attribute key used internally by `on-load` will provide a much nicer interface to achieve the same result. eg. `node.hasAttribute(onload.KEY_ATTR)`