### PR TITLE
Make caller argument obligatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ On load/unload events for DOM elements using a MutationObserver
 var onload = require('on-load')
 
 var div = document.createElement('div')
+// Provide on-load and on-unload hooks, and caller name. The latter is required, as it can't be
+// deduced automatically.
 onload(div, function (el) {
   console.log('in the dom')
 }, function (el) {
   console.log('out of the dom')
-})
+}, 'myFunction')
 
 // Will fire the onload
 document.body.appendChild(div)

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = function onload (el, on, off, caller) {
   on = on || function () {}
   off = off || function () {}
   el.setAttribute(KEY_ATTR, 'o' + INDEX)
-  watch['o' + INDEX] = [on, off, 0, caller || onload.caller]
+  watch['o' + INDEX] = [on, off, 0, caller]
   INDEX += 1
   return el
 }

--- a/test.js
+++ b/test.js
@@ -12,7 +12,7 @@ test('onload/onunload', function (t) {
     t.ok(true, 'onunload called')
     document.body.innerHTML = ''
     t.end()
-  })
+  }, 'test')
   document.body.appendChild(el)
   document.body.removeChild(el)
 })
@@ -25,7 +25,7 @@ test('passed el reference', function (t) {
       t.equal(el, tree, 'onload passed element reference for page1')
     }, function (el) {
       t.equal(el, tree, 'onunload passed element reference for page1')
-    })
+    }, 'page1')
   }
   function page2 () {
     var tree = yo`<div>page2</div>`
@@ -33,7 +33,7 @@ test('passed el reference', function (t) {
       t.equal(el.textContent, 'page2', 'onload passed element reference for page2')
     }, function (el) {
       t.equal(el.textContent, 'page2', 'onunload passed element reference for page2')
-    })
+    }, 'page2')
   }
 
   var root = page1()
@@ -62,7 +62,7 @@ test('nested', function (t) {
     t.ok(true, 'onunload called')
     document.body.innerHTML = ''
     t.end()
-  })
+  }, 'test')
   e2.appendChild(e3)
   e2.removeChild(e3)
 })
@@ -77,7 +77,7 @@ test('complex', function (t) {
       state.push('on')
     }, function () {
       state.push('off')
-    })
+    }, 'test')
     return el
   }
 
@@ -120,7 +120,7 @@ test('complex nested', function (t) {
       state.push('on')
     }, function () {
       state.push('off')
-    })
+    }, 'test')
     return el
   }
   function app (page) {
@@ -195,14 +195,14 @@ test('fire on same node but not from the same caller', function (t) {
       results.push('page1 on')
     }, function () {
       results.push('page1 off')
-    })
+    }, 'page1')
   }
   function page2 (contents) {
     return onload(yo`<div id="choo-root">${contents}</div>`, function () {
       results.push('page2 on')
     }, function () {
       results.push('page2 off')
-    })
+    }, 'page2')
   }
   var root = page1()
   document.body.appendChild(root)
@@ -250,7 +250,7 @@ test.skip('operates with memoized elements', function (t) {
       results.push('sub on')
     }, function () {
       results.push('sub off')
-    })
+    }, 'sub')
   }
   var saved = null
   function parent () {
@@ -258,7 +258,7 @@ test.skip('operates with memoized elements', function (t) {
       results.push('parent on')
     }, function () {
       results.push('parent off')
-    })
+    }, 'parent')
     return saved
   }
   function app () {


### PR DESCRIPTION
The technique for deducing the `caller` argument to `onload` is unsound, as `Function.caller` is disallowed in strict mode and apparently generally considered [a bad idea](https://medium.com/@bmeurer/function-caller-considered-harmful-45f06916c907).

This patch makes the caller argument obligatory. **However: How should we test that `caller` is passed? Throw an exception?**

Also, if anyone has suggestions for some safe way of auto-generating the `caller` parameter rather than resorting to `Function.caller`, that would be great.

Fixes #15 