### PR TITLE
on-load should be a no-op on the server

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "on-load",
   "version": "3.2.1",
   "description": "On load/unload events for DOM elements using a MutationObserver",
-  "main": "index.js",
+  "main": "server.js",
+  "browser": "index.js",
   "scripts": {
     "start": "wzrd test.js:bundle.js",
     "test": "standard && browserify test.js | testron"

--- a/server.js
+++ b/server.js
@@ -1,0 +1,1 @@
+module.exports = function () {}


### PR DESCRIPTION
In node, on-load shouldn't attempt to do anything since with later versions of
bel (which use pelo), the returned result is a string and not a "DOM" object
like in bel < 5.

This will fix shama/bel#80