### PR TITLE
Allow on-load to load in the <head> tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,16 @@ if (window && window.MutationObserver) {
       eachMutation(mutations[i].addedNodes, turnon)
     }
   })
+  if (document.body) {
+    beginObserve(observer)
+  } else {
+    document.addEventListener('DOMContentLoaded', function (event) {
+      beginObserve(observer)
+    })
+  }
+}
+
+function beginObserve (observer) {
   observer.observe(document.body, {
     childList: true,
     subtree: true,


### PR DESCRIPTION
This prevents the observer from trying to attach before there is a body.  This would occur when loading `on-load` from a non-deferred script tag in the head.