### PR TITLE
Assert document.body is available

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 /* global MutationObserver */
 var document = require('global/document')
 var window = require('global/window')
+var assert = require('assert')
 var watch = Object.create(null)
 var KEY_ID = 'onloadid' + (new Date() % 9e6).toString(36)
 var KEY_ATTR = 'data-' + KEY_ID
@@ -38,6 +39,7 @@ function beginObserve (observer) {
 }
 
 module.exports = function onload (el, on, off, caller) {
+  assert(document.body, 'on-load: will not work prior to DOMContentLoaded')
   on = on || function () {}
   off = off || function () {}
   el.setAttribute(KEY_ATTR, 'o' + INDEX)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "3.2.2",
   "description": "On load/unload events for DOM elements using a MutationObserver",
   "main": "server.js",
-  "browser": "index.js",
+  "browser": {
+    "assert": "nanoassert",
+    "./server.js": "index.js"
+  },
   "scripts": {
     "start": "wzrd test.js:bundle.js",
     "test": "standard && browserify test.js | testron"
@@ -30,7 +33,8 @@
   },
   "homepage": "https://github.com/shama/on-load",
   "dependencies": {
-    "global": "^4.3.0"
+    "global": "^4.3.0",
+    "nanoassert": "^1.1.0"
   },
   "devDependencies": {
     "browserify": "^13.0.0",


### PR DESCRIPTION
We can't use on-load prior to DOMContentAvailable so we should assert
that document.body exists prior to trying to do anything with it.