### PR TITLE
observe document.documentElement instead of document.body

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ if (window && window.MutationObserver) {
 }
 
 function beginObserve (observer) {
-  observer.observe(document.body, {
+  observer.observe(document.documentElement, {
     childList: true,
     subtree: true,
     attributes: true,


### PR DESCRIPTION
currently, onload does not handle the following as one might hope.

```js
document.body = onload(bel`<body>hello world</body>`, () => console.log('loaded'))
```

by observing changes to the root document element instead of the body element, this works as expected. are there reasons not to do this?