### PR TITLE
unload only if not mounted

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,9 @@ if (window && window.MutationObserver) {
         eachAttr(mutations[i], turnon, turnoff)
         continue
       }
-      eachMutation(mutations[i].removedNodes, turnoff)
+      eachMutation(mutations[i].removedNodes, function (index, el) {
+        if (!document.documentElement.contains(el)) turnoff(index, el)
+      })
       eachMutation(mutations[i].addedNodes, turnon)
     }
   })

--- a/index.js
+++ b/index.js
@@ -18,7 +18,9 @@ if (window && window.MutationObserver) {
       eachMutation(mutations[i].removedNodes, function (index, el) {
         if (!document.documentElement.contains(el)) turnoff(index, el)
       })
-      eachMutation(mutations[i].addedNodes, turnon)
+      eachMutation(mutations[i].addedNodes, function (index, el) {
+        if (document.documentElement.contains(el)) turnon(index, el)
+      })
     }
   })
   if (document.body) {

--- a/test.js
+++ b/test.js
@@ -8,13 +8,13 @@ test('onload/onunload', function (t) {
   el.textContent = 'test'
   onload(el, function () {
     t.ok(true, 'onload called')
+    document.body.removeChild(el)
   }, function () {
     t.ok(true, 'onunload called')
     document.body.innerHTML = ''
     t.end()
   })
   document.body.appendChild(el)
-  document.body.removeChild(el)
 })
 
 test('assign key attr', function (t) {
@@ -66,13 +66,13 @@ test('nested', function (t) {
   var e3 = document.createElement('div')
   onload(e3, function () {
     t.ok(true, 'onload called')
+    e2.removeChild(e3)
   }, function () {
     t.ok(true, 'onunload called')
     document.body.innerHTML = ''
     t.end()
   })
   e2.appendChild(e3)
-  e2.removeChild(e3)
 })
 
 test('complex', function (t) {


### PR DESCRIPTION
currently on-load emits unload if a node is removed from dom. this pr requires that the node also not be mounted on the dom. 

https://github.com/shama/on-load/issues/25 describes one situation in which this is helpful. this change is also helpful for managing nested elements, each with their own load/unload handlers. if an element is re-rendered, child elements only emit unload if no longer contained by the dom.