### PR TITLE
Use released version of testron instead of fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "electron-prebuilt": "^0.36.9",
     "standard": "^10.0.3",
     "tape": "^4.6.0",
-    "testron": "lachenmayer/testron#fs-unlink-error",
+    "testron": "^1.2.1",
     "wzrd": "^1.4.0",
     "yo-yo": "^1.2.1"
   }


### PR DESCRIPTION
This includes the changes in my fork. https://github.com/shama/testron/pull/8