### PR TITLE
observe document.documentElement again

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 /* global MutationObserver */
 var document = require('global/document')
 var window = require('global/window')
-var assert = require('assert')
 var watch = Object.create(null)
 var KEY_ID = 'onloadid' + (new Date() % 9e6).toString(36)
 var KEY_ATTR = 'data-' + KEY_ID
@@ -24,12 +23,16 @@ if (window && window.MutationObserver) {
     }
   })
 
-  if (document.readyState === 'complete') startObserving(observer)()
-  else document.addEventListener('DOMContentLoaded', startObserving(observer))
+  observer.observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeOldValue: true,
+    attributeFilter: [KEY_ATTR]
+  })
 }
 
 module.exports = function onload (el, on, off, caller) {
-  assert(document.body, 'on-load: will not work prior to DOMContentLoaded')
   on = on || function () {}
   off = off || function () {}
   el.setAttribute(KEY_ATTR, 'o' + INDEX)
@@ -40,18 +43,6 @@ module.exports = function onload (el, on, off, caller) {
 
 module.exports.KEY_ATTR = KEY_ATTR
 module.exports.KEY_ID = KEY_ID
-
-function startObserving (obs) {
-  return function () {
-    obs.observe(document.body, {
-      childList: true,
-      subtree: true,
-      attributes: true,
-      attributeOldValue: true,
-      attributeFilter: [KEY_ATTR]
-    })
-  }
-}
 
 function turnon (index, el) {
   if (watch[index][0] && watch[index][2] === 0) {


### PR DESCRIPTION
https://github.com/shama/on-load/pull/18 was proposed back when when on-load was observing `document.body` and reverts https://github.com/shama/on-load/pull/34.

https://github.com/shama/on-load/pull/18 forces the user to listen for the DOMContentLoaded event before mutating the DOM if they want to observe those mutations. Before this change, the user could mutate the dom even while `document.readyState` was `loading` and observe changes without any trouble. E.g. this breaks the example in [morphable](https://github.com/lukeburns/morphable/blob/master/example/index.js) which relies on on-load.

Mutating the dom while the document is still loading won't cause problems when we observe `document.documentElement`, because `<html></html>` always exists, even if the script is loaded in `<head></head>`.

This PR goes back to observing `document.documentElement`. With this change, the following works again as expected.

index.js browserified into bundle.js:
```js
const html = require('nanohtml')
const onload = require('on-load')

document.body = onload(html`<body>hello world</body>`, () => console.log('loaded body'))
```

index.html:
```html
<html>
  <head>
    <script src="bundle.js"></script>
  </head>
</html>  
```

Note, that `document.documentElement` is [supported even by old browsers](https://quirksmode.org/dom/core/#t133) so this approach is also less restrictive.