### PR TITLE
fix id clashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 var document = require('global/document')
 var window = require('global/window')
 var watch = Object.create(null)
-var KEY_ID = 'onloadid' + (new Date() % 9e6).toString(36)
+var KEY_ID = 'onloadid' + Math.random().toString(36) + '.' + (new Date() % 9e6).toString(36)
 var KEY_ATTR = 'data-' + KEY_ID
 var INDEX = 0
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 var document = require('global/document')
 var window = require('global/window')
 var watch = Object.create(null)
-var KEY_ID = 'onloadid' + Math.random().toString(36) + '.' + (new Date() % 9e6).toString(36)
+var KEY_ID = 'onloadid' + Math.random().toString(36).slice(2)
 var KEY_ATTR = 'data-' + KEY_ID
 var INDEX = 0
 


### PR DESCRIPTION
This fixes a bug where if for some reason you have two on-loads in your dependency tree, then the timing based id can clash if the two versions are loading in the same millisecond (actual bug we hit).